### PR TITLE
doc: update mount command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ end
 Add this line to config/routes.rb
 
 ```ruby
-mount Que::Web::Engine => '/que_web'
+mount Que::View::Engine => '/que_view'
 ```
 
 Add this line to assets/config/manifest.js


### PR DESCRIPTION
The mount command in the README is using the que-web module name: `Que::Web`. Instead use the actual module name `Que::View` so no one will face the following error when testing the gem.

```ruby
/Users/blabla/testing-que/config/routes.rb:9:in `block in <main>': uninitialized constant Que::Web (NameError)

  mount Que::Web::Engine => "/que_web"
                ^^^^^^^^
```
