### PR TITLE
Handle jobs without arguments

### DIFF
--- a/app/views/que/view/jobs/index.html.erb
+++ b/app/views/que/view/jobs/index.html.erb
@@ -51,7 +51,7 @@
         <td><%= job[:queue] %></td>
         <td><%= job[:run_at].strftime("%Y-%m-%d %H:%M:%S") %></td>
         <td>
-          <% job.dig(:args, 0, :arguments).each do |argument| %>
+          <% Array(job.dig(:args, 0, :arguments)).each do |argument| %>
             <p><%= argument %></p>
           <% end %>
         </td>


### PR DESCRIPTION
I have a project that has a scheduled job that receives no arguments.

Displaying the job fails because the view attempts to iterate over `nil`.

…And there are no specs?