### PR TITLE
Add backtrace to the job view

### DIFF
--- a/app/views/que/view/jobs/show.html.erb
+++ b/app/views/que/view/jobs/show.html.erb
@@ -44,6 +44,12 @@
           <%= format_error(@job) %>
         </td>
       </tr>
+      <tr>
+        <th>Backtrace</th>
+        <td>
+          <%= @job[:last_error_backtrace].to_s.split("\n").join("<br>").html_safe %>
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
Debugging errors is difficult without the backtrace information.