### PR TITLE
Remove sassc-rails dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     que-view (0.3.6)
       que (> 2.0)
       rails (> 6.0.0)
-      sassc-rails
 
 GEM
   remote: https://rubygems.org/
@@ -94,7 +93,6 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
-    ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -128,6 +126,8 @@ GEM
       net-protocol
     nio4r (2.7.0)
     nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.24.0)
     parser (3.3.0.5)
@@ -205,24 +205,8 @@ GEM
       rubocop (~> 1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
-    sprockets (4.2.1)
-      concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      sprockets (>= 3.0.0)
     stringio (3.1.0)
     thor (1.3.0)
-    tilt (2.3.0)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -235,6 +219,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-23
 
 DEPENDENCIES
   bundler

--- a/que-view.gemspec
+++ b/que-view.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'que', '> 2.0'
   spec.add_dependency 'rails', '> 6.0.0'
-  spec.add_dependency 'sassc-rails'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pg', '> 1.0'


### PR DESCRIPTION
Overview:
This pull request aims to remove the unwanted `sassc-rails` dependency from our gem. The `sassc-rails` gem, which compiles Sass/SCSS stylesheets, is not necessary for this gem.

Changes Introduced:

Gemfile:
1. Removed the `sassc-rails` entry.