### PR TITLE
Search by job_class attribute

### DIFF
--- a/lib/que/view/version.rb
+++ b/lib/que/view/version.rb
@@ -2,6 +2,6 @@
 
 module Que
   module View
-    VERSION = '0.4.1'
+    VERSION = '0.4.2'
   end
 end


### PR DESCRIPTION
Fixing the following behaviour for jobs without args:
<img width="627" alt="Screenshot 2025-01-08 at 15 02 41" src="https://github.com/user-attachments/assets/b41a5603-08a8-48ec-9a76-6c0f22aa4273" />
 
In `que` repository we observed that there is possibility to search by entity attribute as well as by content of args attribute:
https://github.com/que-rb/que/blob/master/lib/que/active_record/model.rb#L26

Backporting that behaviour into `que-view`, hope that makes sense :)
