### PR TITLE
Add delete and reschedule filtered jobs buttons

### DIFF
--- a/app/controllers/que/view/jobs_controller.rb
+++ b/app/controllers/que/view/jobs_controller.rb
@@ -48,6 +48,24 @@ module Que
         )
       end
 
+      def reschedule_filtered
+        job_ids = params[:job_ids] || []
+        updated_rows = ::Que::View.reschedule_jobs_by_ids(job_ids, Time.now)
+        redirect_to(
+          jobs_path(status: params[:status]),
+          notice: updated_rows.empty? ? 'No jobs rescheduled' : "#{updated_rows.count} jobs rescheduled"
+        )
+      end
+
+      def destroy_filtered
+        job_ids = params[:job_ids] || []
+        updated_rows = ::Que::View.delete_jobs_by_ids(job_ids)
+        redirect_to(
+          jobs_path(status: params[:status]),
+          notice: updated_rows.empty? ? 'No jobs deleted' : "#{updated_rows.count} jobs deleted"
+        )
+      end
+
       private
 
       def find_queue_names

--- a/app/views/que/view/jobs/index.html.erb
+++ b/app/views/que/view/jobs/index.html.erb
@@ -2,9 +2,8 @@
 <%= form_with url: jobs_path, method: :get, class: 'search-form' do |form| %>
   <%= form.hidden_field :status, value: params[:status] %>
   <div class="row">
-    <%= form.select :queue_name, options_for_select(@queue_names, params[:queue_name]), {}, class: 'form-select' %>
-    <%= form.select :job_name, options_for_select(@job_names, params[:job_name]), {}, class: 'form-select' %>
-    <%= form.submit 'Search', class: 'btn-primary' %>
+    <%= form.select :queue_name, options_for_select(@queue_names, params[:queue_name]), {}, class: 'form-select', onchange: 'this.form.submit();' %>
+    <%= form.select :job_name, options_for_select(@job_names, params[:job_name]), {}, class: 'form-select', onchange: 'this.form.submit();' %>
   </div>
 <% end %>
 <% if @pagination && @pagination.total_pages > 1 %>
@@ -68,8 +67,15 @@
   </tbody>
 </table>
 <% if @pagination && %w[failing scheduled].include?(params[:status]) %>
+  <% job_ids = @jobs.map { |job| job[:id] } %>
+  <% has_filters = params[:queue_name].present? || params[:job_name].present? %>
   <div class="row">
-    <%= button_to 'Run All', reschedule_all_jobs_path(status: params[:status]), class: 'btn-danger', method: :post, onclick: "return confirm('Are you sure you wish to reschedule all jobs?')" %>
-    <%= button_to 'Delete All', destroy_all_jobs_path(status: params[:status]), class: 'btn-danger', method: :delete, onclick: "return confirm('Are you sure you wish to delete all jobs?')" %>
+    <% if has_filters && job_ids.any? %>
+      <%= button_to "Run (#{job_ids.count})", reschedule_filtered_jobs_path, params: { job_ids: job_ids, status: params[:status] }, class: 'btn-primary', method: :post, onclick: "return confirm('Are you sure you wish to reschedule #{job_ids.count} job(s) on this page?')" %>
+      <%= button_to "Delete (#{job_ids.count})", destroy_filtered_jobs_path, params: { job_ids: job_ids, status: params[:status] }, class: 'btn-primary', method: :delete, onclick: "return confirm('Are you sure you wish to delete #{job_ids.count} job(s) on this page?')" %>
+    <% else %>
+      <%= button_to 'Run All', reschedule_all_jobs_path(status: params[:status]), class: 'btn-danger', method: :post, onclick: "return confirm('Are you sure you wish to reschedule all (#{job_ids.count}) jobs?')" %>
+      <%= button_to 'Delete All', destroy_all_jobs_path(status: params[:status]), class: 'btn-danger', method: :delete, onclick: "return confirm('Are you sure you wish to delete all (#{job_ids.count}) jobs?')" %>
+    <% end %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Que::View::Engine.routes.draw do
   resources :jobs, only: %i[index show update destroy] do
     post :reschedule_all, on: :collection
     delete :destroy_all, on: :collection
+    post :reschedule_filtered, on: :collection
+    delete :destroy_filtered, on: :collection
   end
   resources :queue_metrics, only: %i[index]
 

--- a/lib/que/view.rb
+++ b/lib/que/view.rb
@@ -38,7 +38,7 @@ module Que
                    :fetch_queue_names, :fetch_job_names,
                    :fetch_running_jobs, :fetch_failing_jobs, :fetch_scheduled_jobs, :fetch_finished_jobs,
                    :fetch_expired_jobs, :fetch_job,
-                   :delete_failing_jobs, :delete_scheduled_jobs, :delete_job,
-                   :reschedule_scheduled_jobs, :reschedule_failing_jobs, :reschedule_job
+                   :delete_failing_jobs, :delete_scheduled_jobs, :delete_job, :delete_jobs_by_ids,
+                   :reschedule_scheduled_jobs, :reschedule_failing_jobs, :reschedule_job, :reschedule_jobs_by_ids
   end
 end


### PR DESCRIPTION
This PR adds "delete" and "reschdule" buttons for jobs that are within scope of the current filter. This minimises the risk that a developer can accidentally press "delete all" when viewing jobs of a certain class.

With no filtering by queue or job name:
<img width="1236" height="1434" alt="image" src="https://github.com/user-attachments/assets/e73bbec8-b401-49be-a6e6-94b6babe8cb0" />

With filtering by queue or job name:
<img width="1548" height="1218" alt="image" src="https://github.com/user-attachments/assets/fe643649-8c7b-4706-9c08-7befc8e3f608" />

